### PR TITLE
Fix repo url truncation

### DIFF
--- a/src/libs/utils.py
+++ b/src/libs/utils.py
@@ -317,7 +317,7 @@ def extract_repo_info(location: str) -> Optional[Dict[str, str]]:
             return {
                 "platform": platform,
                 "owner": owner,
-                "repo": repo.rstrip(".git"),
+                "repo": repo.removesuffix(".git"),
                 "ref": ref or "master",  # Default to master if no ref specified
             }
 


### PR DESCRIPTION
There was an issue with dependency url extraction where some urls would incorrectly get part of their repo name removed.

For example, a dependency with url like `https://github.com/karlseguin/http.zig` would be displayed as `https://github.com/karlseguin/http.z` in Zigistry.

You can see this example in https://zigistry.dev/packages/github/sea-grass/goku/:
<img width="549" alt="Screenshot 2025-05-02 at 11 57 12 AM" src="https://github.com/user-attachments/assets/acb25a92-adf2-4a93-8574-2043e76fa2dc" />

---

The fix was to replace `.rstrip(".git")` with `.removesuffix(".git")` - rstrip removes any combination of the provided characters from a string, while removesuffix only removes exactly the provided string.